### PR TITLE
remove dockerfile entrypoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build the Docker container
+        run: docker build -t basic:test .
+
+      # Cache test data to avoid repeated download
+      - uses: actions/cache@v3
+        id: cache-data
+        with:
+          path: |
+            ~/data/exemplar-001-cycle6.ome.tif
+          key: testdata-2022-08-25
+
+      # Download test data only if no cache is present
+      - name: Download test data
+        if: steps.cache-data.outputs.cache-hit != 'true'
+        run: |
+          mkdir ~/data
+          cd ~/data
+          curl -f -o exemplar-001-cycle-06.ome.tiff \
+            https://mcmicro.s3.amazonaws.com/exemplars/001/exemplar-001/raw/exemplar-001-cycle-06.ome.tiff
+          
+      - name: Test the container
+        run: |
+          cd ~/data
+          rm -f test-dfp.tif
+          rm -f test-ffp.tif
+          docker run -u root -v "$PWD":/data basic:test /bin/bash -c "cd /data; \
+            /opt/fiji/Fiji.app/ImageJ-linux64 --ij2 --headless \
+              --run /opt/fiji/imagej_basic_ashlar.py \
+              'filename=\"exemplar-001-cycle-06.ome.tiff\",output_dir=\".\",experiment_name=\"test\"'"
+
+      # If the action is successful, the output will be available as a downloadable artifact
+      - name: Upload processed result
+        uses: actions/upload-artifact@v2
+        with:
+          name: exemplar-001-cycle-06
+          path: |
+            ~/data/test-dfp.tif
+            ~/data/test-ffp.tif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM fiji/fiji:fiji-openjdk-8
 
+ENTRYPOINT []
+
 RUN wget https://www.helmholtz-muenchen.de/fileadmin/ICB/software/BaSiC/BaSiCPlugin.zip && \
     unzip BaSiCPlugin.zip && \
     mv BaSiCPlugin/BaSiC_.jar Fiji.app/plugins/ && \


### PR DESCRIPTION
The entrypoint introduced from parent image (Fiji) is not compatible with some workflow languages (CWL, Galaxy) and can not always be controlled as an arg when invoking docker run.  